### PR TITLE
Don't show serial number in recovery

### DIFF
--- a/fastboot/fastboot.cpp
+++ b/fastboot/fastboot.cpp
@@ -44,7 +44,6 @@ Device::BuiltinAction StartFastboot(Device* device, const std::vector<std::strin
   title_lines.push_back("Bootloader version - " + android::base::GetProperty("ro.bootloader", ""));
   title_lines.push_back("Baseband version - " +
                         android::base::GetProperty("ro.build.expect.baseband", ""));
-  title_lines.push_back("Serial number - " + android::base::GetProperty("ro.serialno", ""));
   title_lines.push_back(std::string("Secure boot - ") +
                         ((android::base::GetProperty("ro.secure", "") == "1") ? "yes" : "no"));
   title_lines.push_back("HW version - " + android::base::GetProperty("ro.revision", ""));


### PR DESCRIPTION
To stop people leaking it during installation photos